### PR TITLE
Acknowledge defaults

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -6,10 +6,4 @@
 [core]
   excludesfile = ~/.gitignore
 
-[color]
-  ui = auto
-
-[push]
-  default = simple
-
 ### ~/.gitconfig: User configuration for `git`


### PR DESCRIPTION
Don't set things that are defaults in recent git versions

color ui=auto and push default simple have been defaults in the past few versions of git